### PR TITLE
NPL-1879 Support using the nucleus-npm npm registry

### DIFF
--- a/.github/workflows/nucleus-deploy-sam-stack.yml
+++ b/.github/workflows/nucleus-deploy-sam-stack.yml
@@ -56,7 +56,7 @@ jobs:
     - name: 'Create .npmrc'
       shell: bash
       run: |
-        echo "registry=https://moetech.jfrog.io/artifactory/api/npm/npm/" > .npmrc
+        echo "registry=https://moetech.jfrog.io/artifactory/api/npm/nucleus-npm/" > .npmrc
         echo "_authToken = ${{ secrets.JFROG_AUTH_TOKEN }}" >> .npmrc
         echo "always-auth = true" >> .npmrc
 

--- a/.github/workflows/nucleus-deploy-sam-stack.yml
+++ b/.github/workflows/nucleus-deploy-sam-stack.yml
@@ -60,6 +60,7 @@ jobs:
     - name: 'Create .npmrc'
       shell: bash
       run: |
+        echo "Using registry: ${{ inputs.jfrog_npm_registry }}"
         echo "registry=https://moetech.jfrog.io/artifactory/api/npm/${{ inputs.jfrog_npm_registry }}/" > .npmrc
         echo "_authToken = ${{ secrets.JFROG_AUTH_TOKEN }}" >> .npmrc
         echo "always-auth = true" >> .npmrc

--- a/.github/workflows/nucleus-deploy-sam-stack.yml
+++ b/.github/workflows/nucleus-deploy-sam-stack.yml
@@ -28,6 +28,10 @@ on:
         required: false
         default: 'false'
         type: string
+      jfrog_npm_registry:
+        description: 'JFrog NPM registry name'
+        default: 'npm'
+        type: string
     secrets:
       JFROG_AUTH_TOKEN:
         required: true
@@ -56,7 +60,7 @@ jobs:
     - name: 'Create .npmrc'
       shell: bash
       run: |
-        echo "registry=https://moetech.jfrog.io/artifactory/api/npm/nucleus-npm/" > .npmrc
+        echo "registry=https://moetech.jfrog.io/artifactory/api/npm/${{ inputs.jfrog_npm_registry }}/" > .npmrc
         echo "_authToken = ${{ secrets.JFROG_AUTH_TOKEN }}" >> .npmrc
         echo "always-auth = true" >> .npmrc
 

--- a/.github/workflows/nucleus-deploy-sam-stack.yml
+++ b/.github/workflows/nucleus-deploy-sam-stack.yml
@@ -61,7 +61,7 @@ jobs:
       shell: bash
       run: |
         echo "Using registry: ${{ inputs.jfrog_npm_registry }}"
-        echo "registry=https://moetech.jfrog.io/artifactory/api/npm/${{ inputs.jfrog_npm_registry }}/" > .npmrc
+        [ ! -e .npmrc ] && echo "registry=https://moetech.jfrog.io/artifactory/api/npm/${{ inputs.jfrog_npm_registry }}/" > .npmrc
         echo "_authToken = ${{ secrets.JFROG_AUTH_TOKEN }}" >> .npmrc
         echo "always-auth = true" >> .npmrc
 

--- a/.github/workflows/nucleus-deploy-sam-stack.yml
+++ b/.github/workflows/nucleus-deploy-sam-stack.yml
@@ -28,10 +28,6 @@ on:
         required: false
         default: 'false'
         type: string
-      jfrog_npm_registry:
-        description: 'JFrog NPM registry name'
-        default: 'npm'
-        type: string
     secrets:
       JFROG_AUTH_TOKEN:
         required: true
@@ -60,10 +56,13 @@ jobs:
     - name: 'Create .npmrc'
       shell: bash
       run: |
-        echo "Using registry: ${{ inputs.jfrog_npm_registry }}"
-        [ ! -e .npmrc ] && echo "registry=https://moetech.jfrog.io/artifactory/api/npm/${{ inputs.jfrog_npm_registry }}/" > .npmrc
-        echo "_authToken = ${{ secrets.JFROG_AUTH_TOKEN }}" >> .npmrc
-        echo "always-auth = true" >> .npmrc
+          echo "Creating/Updating .npmrc in $PWD"
+          # Create a new .npmrc if there isn't one there already
+          [ ! -e .npmrc ] && "Creating new .npmrc" && echo "registry=https://moetech.jfrog.io/artifactory/api/npm/npm/" > .npmrc
+          # Add a newline to the .npmrc just in case the checked in version doesn't have one already.
+          echo "" >> .npmrc
+          echo "_authToken = ${{ secrets.JFROG_AUTH_TOKEN }}" >> .npmrc
+          echo "always-auth = true" >> .npmrc
 
     - name: Microsoft Teams Deploy Card
       uses: patrickpaulin/ms-teams-deploy-card@master

--- a/.github/workflows/nucleus-website-deployment.yml
+++ b/.github/workflows/nucleus-website-deployment.yml
@@ -43,6 +43,7 @@ jobs:
     - name: 'Create .npmrc'
       shell: bash
       run: |
+        echo "Using registry: ${{ inputs.jfrog_npm_registry }}"
         echo "registry=https://moetech.jfrog.io/artifactory/api/npm/${{ inputs.jfrog_npm_registry }}/" > .npmrc
         echo "_authToken = ${{ secrets.JFROG_AUTH_TOKEN }}" >> .npmrc
         echo "always-auth = true" >> .npmrc

--- a/.github/workflows/nucleus-website-deployment.yml
+++ b/.github/workflows/nucleus-website-deployment.yml
@@ -17,10 +17,6 @@ on:
         description: 'CodeBuild Name'
         required: true
         type: string
-      jfrog_npm_registry:
-        description: 'JFrog NPM registry name'
-        default: 'npm'
-        type: string
     secrets:
       JFROG_AUTH_TOKEN:
         required: true
@@ -43,10 +39,13 @@ jobs:
     - name: 'Create .npmrc'
       shell: bash
       run: |
-        echo "Using registry: ${{ inputs.jfrog_npm_registry }}"
-        [ ! -e .npmrc ] && echo "registry=https://moetech.jfrog.io/artifactory/api/npm/${{ inputs.jfrog_npm_registry }}/" > .npmrc
-        echo "_authToken = ${{ secrets.JFROG_AUTH_TOKEN }}" >> .npmrc
-        echo "always-auth = true" >> .npmrc
+          echo "Creating/Updating .npmrc in $PWD"
+          # Create a new .npmrc if there isn't one there already
+          [ ! -e .npmrc ] && "Creating new .npmrc" && echo "registry=https://moetech.jfrog.io/artifactory/api/npm/npm/" > .npmrc
+          # Add a newline to the .npmrc just in case the checked in version doesn't have one already.
+          echo "" >> .npmrc
+          echo "_authToken = ${{ secrets.JFROG_AUTH_TOKEN }}" >> .npmrc
+          echo "always-auth = true" >> .npmrc
     
     - name: Microsoft Teams Deploy Card
       uses: patrickpaulin/ms-teams-deploy-card@master

--- a/.github/workflows/nucleus-website-deployment.yml
+++ b/.github/workflows/nucleus-website-deployment.yml
@@ -17,6 +17,10 @@ on:
         description: 'CodeBuild Name'
         required: true
         type: string
+      jfrog_npm_registry:
+        description: 'JFrog NPM registry name'
+        default: 'npm'
+        type: string
     secrets:
       JFROG_AUTH_TOKEN:
         required: true
@@ -39,7 +43,7 @@ jobs:
     - name: 'Create .npmrc'
       shell: bash
       run: |
-        echo "registry=https://moetech.jfrog.io/artifactory/api/npm/nucleus-npm/" > .npmrc
+        echo "registry=https://moetech.jfrog.io/artifactory/api/npm/${{ inputs.jfrog_npm_registry }}/" > .npmrc
         echo "_authToken = ${{ secrets.JFROG_AUTH_TOKEN }}" >> .npmrc
         echo "always-auth = true" >> .npmrc
     

--- a/.github/workflows/nucleus-website-deployment.yml
+++ b/.github/workflows/nucleus-website-deployment.yml
@@ -39,7 +39,7 @@ jobs:
     - name: 'Create .npmrc'
       shell: bash
       run: |
-        echo "registry=https://moetech.jfrog.io/artifactory/api/npm/npm/" > .npmrc
+        echo "registry=https://moetech.jfrog.io/artifactory/api/npm/nucleus-npm/" > .npmrc
         echo "_authToken = ${{ secrets.JFROG_AUTH_TOKEN }}" >> .npmrc
         echo "always-auth = true" >> .npmrc
     

--- a/.github/workflows/nucleus-website-deployment.yml
+++ b/.github/workflows/nucleus-website-deployment.yml
@@ -44,7 +44,7 @@ jobs:
       shell: bash
       run: |
         echo "Using registry: ${{ inputs.jfrog_npm_registry }}"
-        echo "registry=https://moetech.jfrog.io/artifactory/api/npm/${{ inputs.jfrog_npm_registry }}/" > .npmrc
+        [ ! -e .npmrc ] && echo "registry=https://moetech.jfrog.io/artifactory/api/npm/${{ inputs.jfrog_npm_registry }}/" > .npmrc
         echo "_authToken = ${{ secrets.JFROG_AUTH_TOKEN }}" >> .npmrc
         echo "always-auth = true" >> .npmrc
     

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -51,10 +51,9 @@ jobs:
           echo "Using registry: ${{ inputs.jfrog_npm_registry }}"
           [ -e .npmrc ] && cat .npmrc
           [ ! -e .npmrc ] && "Creating new .npmrc" && echo "registry=https://moetech.jfrog.io/artifactory/api/npm/${{ inputs.jfrog_npm_registry }}/" > .npmrc
+          echo "" >> .npmrc
           echo "_authToken = ${{ secrets.JFROG_AUTH_TOKEN }}" >> .npmrc
           echo "always-auth = true" >> .npmrc
-          echo "------"
-          head -1 .npmrc
 
       - name: Use Node.js ${{ matrix.node-version }} on ${{ matrix.os }}
         uses: actions/setup-node@v1

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -50,7 +50,7 @@ jobs:
           echo "Creating/Updating .npmrc in $PWD"
           echo "Using registry: ${{ inputs.jfrog_npm_registry }}"
           [ -e .npmrc ] && cat .npmrc
-          [ ! -e .npmrc ] && && "Creating new .npmrc" && echo "registry=https://moetech.jfrog.io/artifactory/api/npm/${{ inputs.jfrog_npm_registry }}/" > .npmrc
+          [ ! -e .npmrc ] && "Creating new .npmrc" && echo "registry=https://moetech.jfrog.io/artifactory/api/npm/${{ inputs.jfrog_npm_registry }}/" > .npmrc
           echo "_authToken = ${{ secrets.JFROG_AUTH_TOKEN }}" >> .npmrc
           echo "always-auth = true" >> .npmrc
           echo "------"

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -48,7 +48,7 @@ jobs:
         shell: bash
         run: |
           echo "Using registry: ${{ inputs.jfrog_npm_registry }}"
-          echo "registry=https://moetech.jfrog.io/artifactory/api/npm/${{ inputs.jfrog_npm_registry }}/" > .npmrc
+        [ ! -e .npmrc ] && echo "registry=https://moetech.jfrog.io/artifactory/api/npm/${{ inputs.jfrog_npm_registry }}/" > .npmrc
           echo "_authToken = ${{ secrets.JFROG_AUTH_TOKEN }}" >> .npmrc
           echo "always-auth = true" >> .npmrc
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -49,6 +49,7 @@ jobs:
         run: |
           echo "Creating/Updating .npmrc in $PWD"
           echo "Using registry: ${{ inputs.jfrog_npm_registry }}"
+          [ -e .npmrc ] && cat .npmrc
           [ ! -e .npmrc ] && echo "registry=https://moetech.jfrog.io/artifactory/api/npm/${{ inputs.jfrog_npm_registry }}/" > .npmrc
           echo "_authToken = ${{ secrets.JFROG_AUTH_TOKEN }}" >> .npmrc
           echo "always-auth = true" >> .npmrc

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -50,9 +50,10 @@ jobs:
           echo "Creating/Updating .npmrc in $PWD"
           echo "Using registry: ${{ inputs.jfrog_npm_registry }}"
           [ -e .npmrc ] && cat .npmrc
-          [ ! -e .npmrc ] && echo "registry=https://moetech.jfrog.io/artifactory/api/npm/${{ inputs.jfrog_npm_registry }}/" > .npmrc
+          [ ! -e .npmrc ] && && "Creating new .npmrc" && echo "registry=https://moetech.jfrog.io/artifactory/api/npm/${{ inputs.jfrog_npm_registry }}/" > .npmrc
           echo "_authToken = ${{ secrets.JFROG_AUTH_TOKEN }}" >> .npmrc
           echo "always-auth = true" >> .npmrc
+          head -1 .npmrc
 
       - name: Use Node.js ${{ matrix.node-version }} on ${{ matrix.os }}
         uses: actions/setup-node@v1

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -17,6 +17,10 @@ on:
         required: true
       COVERAGE_REPORT_GIST_TOKEN:
         required: true
+    jfrog_npm_registry:
+      description: 'JFrog NPM registry name'
+      default: 'npm'
+      type: string
 
 jobs:
   build:
@@ -43,7 +47,7 @@ jobs:
       - name: 'Create .npmrc'
         shell: bash
         run: |
-          echo "registry=https://moetech.jfrog.io/artifactory/api/npm/nucleus-npm/" > .npmrc
+          echo "registry=https://moetech.jfrog.io/artifactory/api/npm/${{ inputs.jfrog_npm_registry }}/" > .npmrc
           echo "_authToken = ${{ secrets.JFROG_AUTH_TOKEN }}" >> .npmrc
           echo "always-auth = true" >> .npmrc
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -47,6 +47,7 @@ jobs:
       - name: 'Create .npmrc'
         shell: bash
         run: |
+          echo "Using registry: ${{ inputs.jfrog_npm_registry }}"
           echo "registry=https://moetech.jfrog.io/artifactory/api/npm/${{ inputs.jfrog_npm_registry }}/" > .npmrc
           echo "_authToken = ${{ secrets.JFROG_AUTH_TOKEN }}" >> .npmrc
           echo "always-auth = true" >> .npmrc

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -12,10 +12,6 @@ on:
         required: false
         type: string
         default: '14.x'
-      jfrog_npm_registry:
-        description: 'JFrog NPM registry name'
-        default: 'npm'
-        type: string
     secrets:
       JFROG_AUTH_TOKEN:
         required: true
@@ -48,9 +44,9 @@ jobs:
         shell: bash
         run: |
           echo "Creating/Updating .npmrc in $PWD"
-          echo "Using registry: ${{ inputs.jfrog_npm_registry }}"
-          [ -e .npmrc ] && cat .npmrc
-          [ ! -e .npmrc ] && "Creating new .npmrc" && echo "registry=https://moetech.jfrog.io/artifactory/api/npm/${{ inputs.jfrog_npm_registry }}/" > .npmrc
+          # Create a new .npmrc if there isn't one there already
+          [ ! -e .npmrc ] && "Creating new .npmrc" && echo "registry=https://moetech.jfrog.io/artifactory/api/npm/npm/" > .npmrc
+          # Add a newline to the .npmrc just in case the checked in version doesn't have one already.
           echo "" >> .npmrc
           echo "_authToken = ${{ secrets.JFROG_AUTH_TOKEN }}" >> .npmrc
           echo "always-auth = true" >> .npmrc

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -47,8 +47,9 @@ jobs:
       - name: 'Create .npmrc'
         shell: bash
         run: |
+          echo "Creating/Updating .npmrc in $PWD"
           echo "Using registry: ${{ inputs.jfrog_npm_registry }}"
-        [ ! -e .npmrc ] && echo "registry=https://moetech.jfrog.io/artifactory/api/npm/${{ inputs.jfrog_npm_registry }}/" > .npmrc
+          [ ! -e .npmrc ] && echo "registry=https://moetech.jfrog.io/artifactory/api/npm/${{ inputs.jfrog_npm_registry }}/" > .npmrc
           echo "_authToken = ${{ secrets.JFROG_AUTH_TOKEN }}" >> .npmrc
           echo "always-auth = true" >> .npmrc
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -53,6 +53,7 @@ jobs:
           [ ! -e .npmrc ] && && "Creating new .npmrc" && echo "registry=https://moetech.jfrog.io/artifactory/api/npm/${{ inputs.jfrog_npm_registry }}/" > .npmrc
           echo "_authToken = ${{ secrets.JFROG_AUTH_TOKEN }}" >> .npmrc
           echo "always-auth = true" >> .npmrc
+          echo "------"
           head -1 .npmrc
 
       - name: Use Node.js ${{ matrix.node-version }} on ${{ matrix.os }}

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -43,7 +43,7 @@ jobs:
       - name: 'Create .npmrc'
         shell: bash
         run: |
-          echo "registry=https://moetech.jfrog.io/artifactory/api/npm/npm/" > .npmrc
+          echo "registry=https://moetech.jfrog.io/artifactory/api/npm/nucleus-npm/" > .npmrc
           echo "_authToken = ${{ secrets.JFROG_AUTH_TOKEN }}" >> .npmrc
           echo "always-auth = true" >> .npmrc
 

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -12,15 +12,15 @@ on:
         required: false
         type: string
         default: '14.x'
+      jfrog_npm_registry:
+        description: 'JFrog NPM registry name'
+        default: 'npm'
+        type: string
     secrets:
       JFROG_AUTH_TOKEN:
         required: true
       COVERAGE_REPORT_GIST_TOKEN:
         required: true
-    jfrog_npm_registry:
-      description: 'JFrog NPM registry name'
-      default: 'npm'
-      type: string
 
 jobs:
   build:


### PR DESCRIPTION
The idea is that for this migration process, we'll have a tokenless .npmrc in each repository that points to the new registry. The updated actions will check if that file is there, if it isn't, use the old registry then add the auth token. Once we're done migrating, we can update the default registry in the actions.